### PR TITLE
Sort methods returned in LanguageServer to return non-inherited metho…

### DIFF
--- a/lib/steep/project/completion_provider.rb
+++ b/lib/steep/project/completion_provider.rb
@@ -10,7 +10,7 @@ module Steep
 
       InstanceVariableItem = Struct.new(:identifier, :range, :type, keyword_init: true)
       LocalVariableItem = Struct.new(:identifier, :range, :type, keyword_init: true)
-      MethodNameItem = Struct.new(:identifier, :range, :definition, :method_type, keyword_init: true)
+      MethodNameItem = Struct.new(:identifier, :range, :definition, :method_type, :inherited_method, keyword_init: true)
 
       attr_reader :source_text
       attr_reader :path
@@ -244,7 +244,8 @@ module Steep
                     items << MethodNameItem.new(identifier: name,
                                                 range: range,
                                                 definition: method,
-                                                method_type: method_type)
+                                                method_type: method_type,
+                                                inherited_method: inherited_method?(method, type))
                   end
                 end
               end
@@ -292,6 +293,10 @@ module Steep
         end
 
         index
+      end
+
+      def inherited_method?(method, type)
+        method.implemented_in.name&.name != type.name.name
       end
     end
   end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -191,7 +191,8 @@ HOVER
               range: range
             ),
             documentation: item.definition.comment&.string,
-            insert_text_format: LanguageServer::Protocol::Constant::InsertTextFormat::SNIPPET
+            insert_text_format: LanguageServer::Protocol::Constant::InsertTextFormat::SNIPPET,
+            sort_text: item.inherited_method ? -1 : 0 # Ensure language server puts non-inherited methods before inherited methods
           )
         when Project::CompletionProvider::InstanceVariableItem
           label = "#{item.identifier}: #{item.type}"


### PR DESCRIPTION

* This ensures that methods defined on a class / module are returned
  earlier in the LSP method autocomplete
* The rationale being the assumption that the most used methods are the ones
  defined in the class rather than inherited ones.
* A _*future*_ improvment might make this sort by proximity to the current class,
  e.g. `class One < Two < Three` could return the methods defined in the source of `One`,
  then the methods defined in the source of `Two`, and then `Three`.