### PR TITLE
Don't autocomplete initialize

### DIFF
--- a/lib/steep/project/completion_provider.rb
+++ b/lib/steep/project/completion_provider.rb
@@ -241,6 +241,7 @@ module Steep
               if name.to_s.start_with?(prefix)
                 if word_name?(name.to_s)
                   method.method_types.each do |method_type|
+                    next if disallowed_method?(name)
                     items << MethodNameItem.new(identifier: name,
                                                 range: range,
                                                 definition: method,
@@ -297,6 +298,13 @@ module Steep
 
       def inherited_method?(method, type)
         method.implemented_in&.name&.name != type.name&.name
+      end
+
+      def disallowed_method?(name)
+        # initialize isn't invoked by developers when creating
+        # instances of new classes, so don't show it as
+        # an LSP option
+        name == :initialize
       end
     end
   end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -60,7 +60,7 @@ self.cl
         end
 
         provider.run(line: 1, column: 5).tap do |items|
-          assert_equal [:class, :initialize, :itself, :nil?, :tap, :to_s], items.map(&:identifier).sort
+          assert_equal [:class, :itself, :nil?, :tap, :to_s], items.map(&:identifier).sort
         end
       end
     end
@@ -104,7 +104,6 @@ end
         provider.run(line: 1, column: 4).tap do |items|
           assert_equal [
             { :identifier=>:class, :inherited_method=>true },
-            { :identifier=>:initialize, :inherited_method=>true },
             { :identifier=>:itself, :inherited_method=>true },
             { :identifier=>:nil?, :inherited_method=>true },
             { :identifier=>:size, :inherited_method=>false },
@@ -161,12 +160,12 @@ end
       EOR
 
         provider.run(line: 3, column: 0).tap do |items|
-          assert_equal [:@foo1, :@foo2, :class, :gets, :initialize, :itself, :nil?, :puts, :require, :tap, :to_s, :world],
+          assert_equal [:@foo1, :@foo2, :class, :gets, :itself, :nil?, :puts, :require, :tap, :to_s, :world],
                        items.map(&:identifier).sort
         end
 
         provider.run(line: 5, column: 0).tap do |items|
-          assert_equal [:attr_reader, :block_given?, :class, :gets, :initialize, :itself, :new, :nil?, :puts, :require, :tap, :to_s],
+          assert_equal [:attr_reader, :block_given?, :class, :gets, :itself, :new, :nil?, :puts, :require, :tap, :to_s],
                        items.map(&:identifier).sort
         end
       end


### PR DESCRIPTION
* initialize is a special method in ruby that developer
  wouldn't call on an instance of a class, so let's remove
  it for the autocomplete provided to LSP